### PR TITLE
Allow graceful shutdown in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ FROM node:19.1.0-alpine3.16
 # Arguments
 ARG APP_HOME=/home/node/app
 
+# Ensure proper handling of kernel signals
+RUN apk add tini
+ENTRYPOINT [ "tini", "--" ]
+
 # Create app directory
 WORKDIR ${APP_HOME}
 
@@ -42,4 +46,4 @@ RUN \
 
 EXPOSE 8000
 
-ENTRYPOINT [ "/bin/sh", "-c", "./docker-entrypoint.sh" ]
+CMD [ "./docker-entrypoint.sh" ]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -25,4 +25,4 @@ if [ ! -s "/home/node/app/config/settings.json" ]; then
 fi
 
 # Start the server
-node /home/node/app/server.js
+exec node /home/node/app/server.js


### PR DESCRIPTION
The change in `Dockerfile` implements proper signal handling (see https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals), which in practice means that e.g. `docker stop` will perform graceful shutdown in a fraction of a second instead of timing out after 10 seconds and forcibly killing the container.

The change in `docker-entrypoint.sh` gets rid of the intermediate shell process sitting between `tini` and `node`, to prevent it from inhibiting e.g. the interrupt signal from Ctrl+C.