### PR TITLE
Fix conjoined words in generated prompt

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1458,21 +1458,8 @@ async function Generate(type, automatic_trigger, force_name2) {
             storyString += appendToStoryString(charPersonality, power_user.disable_personality_formatting ? '' : 'Personality: ');
             storyString += appendToStoryString(Scenario, power_user.disable_scenario_formatting ? '' : 'Scenario: ');
         } else {
-            if (charDescription !== undefined) {
-                if (charPersonality.length > 0 && !power_user.disable_personality_formatting) {
-                    charPersonality = name2 + "'s personality: " + charPersonality;
-                }
-            }
-
             storyString += appendToStoryString(charDescription, '');
-
-            if (storyString.endsWith('\n')) {
-                storyString = storyString.slice(0, -1);
-            }
-
-            if (count_view_mes < topAnchorDepth) {
-                storyString += '\n' + appendToStoryString(charPersonality, '');
-            }
+            storyString += appendToStoryString(charPersonality, power_user.disable_personality_formatting ? '' : name2 + "'s personality: ");
         }
 
         if (power_user.custom_chat_separator && power_user.custom_chat_separator.length) {
@@ -1484,9 +1471,6 @@ async function Generate(type, automatic_trigger, force_name2) {
         if (power_user.pin_examples && main_api !== 'openai') {
             for (let example of mesExamplesArray) {
                 if (!is_pygmalion) {
-                    if (!storyString.endsWith('\n')) {
-                        storyString += '\n';
-                    }
                     const replaceString = power_user.disable_examples_formatting ? '' : `This is how ${name2} should talk`;
                     example = example.replace(/<START>/i, replaceString);
                 }
@@ -1645,9 +1629,6 @@ async function Generate(type, automatic_trigger, force_name2) {
                     }
                 }
                 if (!is_pygmalion && Scenario && Scenario.length > 0) {
-                    if (!storyString.endsWith('\n')) {
-                        storyString += '\n';
-                    }
                     storyString += !power_user.disable_scenario_formatting ? `Circumstances and context of the dialogue: ${Scenario}\n` : `${Scenario}\n`;
                 }
                 console.log('calling runGenerate');

--- a/public/script.js
+++ b/public/script.js
@@ -1682,9 +1682,9 @@ async function Generate(type, automatic_trigger, force_name2) {
                         is_add_personality = true;
                         //chatString = chatString.substr(0,chatString.length-1);
                         //anchorAndPersonality = "[Genre: roleplay chat][Tone: very long messages with descriptions]";
-                        if ((anchorTop != "" || charPersonality != "") && !is_pygmalion) {
-                            if (anchorTop != "") charPersonality += ' ';
-                            item += "[" + charPersonality + anchorTop + ']\n';
+                        let personalityAndAnchor = [ charPersonality, anchorTop ].filter(x => x).join(' ');
+                        if (personalityAndAnchor && !is_pygmalion) {
+                            item += "[" + personalityAndAnchor + ']\n';
                         }
                     }
                     if (i >= arrMes.length - 1 && count_view_mes > 8 && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":" && !is_pygmalion) {//For add anchor in end


### PR DESCRIPTION
The prompt generator is pretty inconsistent with where and how it inserts newlines and spaces, depending on which settings are enabled. Some cases are probably harmless, like an extra blank line or two, but I also found a case which leads to malformed words. The amount of dependencies between various settings and edge cases terrifies me, so I focused on fixing that major case #without touching too much code or complicating it further. More details in diff comments.