### PR TITLE
Back to conditional personality at the beginning of the chat

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1460,7 +1460,10 @@ async function Generate(type, automatic_trigger, force_name2) {
             storyString += appendToStoryString(Scenario, power_user.disable_scenario_formatting ? '' : 'Scenario: ');
         } else {
             storyString += appendToStoryString(charDescription, '');
-            storyString += appendToStoryString(charPersonality, power_user.disable_personality_formatting ? '' : name2 + "'s personality: ");
+
+            if (count_view_mes < topAnchorDepth) {
+                storyString += appendToStoryString(charPersonality, power_user.disable_personality_formatting ? '' : name2 + "'s personality: ");
+            }
         }
 
         if (power_user.custom_chat_separator && power_user.custom_chat_separator.length) {


### PR DESCRIPTION
Sorry, I went a bit too far in #123, I only intended termination by newline to be unconditional, not the entire personality block. Realized it now, because I had an unwieldy situation with 2 repos and some manually moved changes, which I finally unified properly and the difference popped up. The effect of this oversight was that for longer chats the personality was mentioned both at the beginning and near the end, instead of just near the end of the prompt.