### PR TITLE
Add Basic Authentication Support to SillyTavern

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -1,11 +1,13 @@
 
 const port = 8000;
 const whitelist = ['127.0.0.1']; //Example for add several IP in whitelist: ['127.0.0.1', '192.168.0.10']
-const whitelistMode = true; //Disabling enabling the ip whitelist mode. true/false
+const whitelistMode = false; //Disabling enabling the ip whitelist mode. true/false
+const basicAuthMode = false; //Toggle basic authentication for endpoints.
+const basicAuthUser = {username: "user", password: "password"}; //Login credentials when basicAuthMode is true.
 const autorun = true; //Autorun in the browser. true/false
 const enableExtensions = true; //Enables support for TavernAI-extras project
 const listen = true; // If true, Can be access from other device or PC. otherwise can be access only from hosting machine.
 
 module.exports = {
-  port, whitelist, whitelistMode, autorun, enableExtensions, listen
+  port, whitelist, whitelistMode, basicAuthMode, basicAuthUser, autorun, enableExtensions, listen
 };

--- a/server.js
+++ b/server.js
@@ -35,6 +35,7 @@ const rimraf = require("rimraf");
 const multer = require("multer");
 const http = require("http");
 const https = require('https');
+const basicAuthMiddleware = require('./src/middleware/basicAuthMiddleware');
 //const PNG = require('pngjs').PNG;
 const extract = require('png-chunks-extract');
 const encode = require('png-chunks-encode');
@@ -193,6 +194,8 @@ const CORS = cors({
 });
 
 app.use(CORS);
+
+if (listen && config.basicAuthMode) app.use(basicAuthMiddleware);
 
 app.use(function (req, res, next) { //Security
     let clientIp = req.connection.remoteAddress;

--- a/server.js
+++ b/server.js
@@ -2398,6 +2398,10 @@ const setupTasks = async function () {
   
     if (autorun) open(autorunUrl.toString());
     console.log('SillyTavern is listening on: ' + tavernUrl);
+    if (listen &&
+        !config.whitelistMode &&
+        !config.basicAuthMode)
+        console.log('Your SillyTavern is currently open to the public. To increase security, consider enabling whitelisting or basic authentication.')
 
     if (fs.existsSync('public/characters/update.txt') && !is_colab) {
         convertStage1();

--- a/src/middleware/basicAuthMiddleware.js
+++ b/src/middleware/basicAuthMiddleware.js
@@ -1,0 +1,39 @@
+/**
+ * When applied, this middleware will ensure the request contains the required header for basic authentication and only
+ * allow access to the endpoint after successful authentication.
+ */
+
+const {dirname} = require('path');
+const appDir = dirname(require.main.filename);
+const config = require(appDir + '/config.conf');
+
+const unauthorizedResponse = (res) => {
+    res.set('WWW-Authenticate', 'Basic realm="SillyTavern", charset="UTF-8"');
+    return res.status(401).send('Authentication required');
+};
+
+const basicAuthMiddleware = function (request, response, callback) {
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) {
+        return unauthorizedResponse(response);
+    }
+
+    const [scheme, credentials] = authHeader.split(' ');
+
+    if (scheme !== 'Basic' || !credentials) {
+        return unauthorizedResponse(response);
+    }
+
+    const [username, password] = Buffer.from(credentials, 'base64')
+        .toString('utf8')
+        .split(':');
+
+    if (username === config.basicAuthUser.username && password === config.basicAuthUser.password) {
+        return callback();
+    } else {
+        return unauthorizedResponse(response);
+    }
+}
+
+module.exports = basicAuthMiddleware;


### PR DESCRIPTION
**Purpose**
Introduces basic authentication support for SillyTavern instances, providing an additional security layer when IP whitelisting is not suitable. For example, this feature is useful when accessing the instance from devices with changing IP addresses.

**Changes**
- Implement a basic authentication middleware.
- Introduce configuration options to enable basic authentication and set the username/password pair (disabled by default).
- Display a warning on server startup if the instance is publicly accessible and neither IP whitelisting nor basic authentication is enabled.

**Usage**
`const basicAuthMode = false;`
`const basicAuthUser = {username: "user", password: "password"}; `

**Discussion**
This is a follow up to https://github.com/Cohee1207/SillyTavern/pull/147, i initially left this out because i didn't want to introduce features that'll only be used by a small subset of users. Imagining most users running SillyTavern this way would use a reverse proxy or similar. After some thought however, i think the server should include a simple and lightweight method for authentication out of the box.