### PR TITLE
Rewrote quote recolor regex

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -878,14 +878,17 @@ function messageFormating(mes, ch_name, isSystem, forceAvatar) {
             .replace(/\*\*(.+?)\*\*/g, "<b>$1</b>")
             .replace(/\n/g, "<br/>");
     } else if (!isSystem) {
+		mes = mes.replace(/```[\s\S]*?```|``[\s\S]*?``|`[\s\S]*?`|(\".+?\")/gm, function(match, p1) {
+		  if (p1) {
+			return "<q>" + p1.replace(/\"/g, "") + "</q>";
+		  } else {
+			return match;
+		  }
+		});
         mes = converter.makeHtml(mes);
         //mes = mes.replace(/{.*}/g, "");
         mes = mes.replace(/{{(\*?.+?\*?)}}/g, "");
 
-
-        mes = mes.replace(/(<code[^>]*>[\s\S]*?<\/code>)|\"(.+?)\"/g, function (match, code, quote) {
-            return code ? code : `<q>${quote}</q>`;
-        });
         mes = mes.replace(/\n/g, "<br/>");
         mes = mes.trim();
 


### PR DESCRIPTION
Found some more issues with quote recoloring, particularly in relation to numbered lists that started with a number higher than 1. Rewrote regex and moved quote replacement to be before HTML conversion.

Tested this change a bit more thoroughly, including multiple sets of backtick-enclosed quote marks on the same line, all seems to be working properly now.

Input:
![image](https://user-images.githubusercontent.com/1149030/234150267-9a72eb9e-31df-41ea-b978-b1b0ba3b81fe.png)

Current output:
![image](https://user-images.githubusercontent.com/1149030/234150296-48b6fe8c-55de-4845-944d-23989f74a43e.png)

New output:
![image](https://user-images.githubusercontent.com/1149030/234150517-75af4d57-7cf8-41b5-b497-35884e1fc900.png)
