### PR TITLE
Process examples in one place and fix some bugs

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1438,7 +1438,7 @@ async function Generate(type, automatic_trigger, force_name2) {
         const blockHeading =
             main_api === 'openai' ? '<START>' : // OpenAI handler always expects it
             power_user.custom_chat_separator ? power_user.custom_chat_separator :
-            power_user.disable_examples_formatting && !(is_pygmalion && power_user.pin_examples) ? '' :
+            power_user.disable_examples_formatting ? '' :
             is_pygmalion ? '<START>' : `This is how ${name2} should talk`;
         let mesExamplesArray = mesExamples.split(/<START>/gi).slice(1).map(block => `${blockHeading}\n${block.trim()}\n`);
 


### PR DESCRIPTION
The logic for handling `<START>` in message exaples was intertwined with almost 200 lines of other code, making it really hard to see what is going on. Now the rules are clear after looking at just one small section. While deciphering all of that, I found 2 bugs.
* A minor token count miscalculation – fixed, see the diff comment.
* *Disable example chats formatting* not respected for pinned examples with Pygmalion – fixed, but I have some doubts and will remove the second commit if you think this is wrong, see the diff comment.