### PR TITLE
Consistent positioning and formatting of pinned examples

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1583,7 +1583,7 @@ async function Generate(type, automatic_trigger, force_name2) {
         // Force pinned examples into the context
         let pinExmString;
         if (power_user.pin_examples) {
-            pinExmString = examplesString = mesExamplesArray.map(example => appendToStoryString(example, '')).join('');
+            pinExmString = examplesString = mesExamplesArray.join('');
         }
 
         // Collect enough messages to fill the context


### PR DESCRIPTION
There is something strange about how example pinning behaves. One could think that what it does is that it simply prevents the examples from being "scrolled out" from the context – which indeed is what happens with TavernAI – but in case of SillyTavern that is not the entire story. ST, besides keeping examples in the context, also flips the scenario/examples order (including world info and scenario anchor). This results in differing prompts even for short chats, where I would presume pinning should not affect the prompt yet:
 TAI        | ST normal   | ST pinning
------------|-------------|------------
DESCRIPTION | DESCRIPTION | DESCRIPTION
PERSONALITY | PERSONALITY | PERSONALITY
<ins>SCENARIO</ins>| <ins>SCENARIO</ins>| EXAMPLES
EXAMPLES    | EXAMPLES    |<ins>SCENARIO</ins>
MESSAGES    | MESSAGES    | MESSAGES

And for long chats the difference evolves into this:
 TAI normal | TAI pinning | ST normal   | ST pinning
------------|-------------|-------------|------------
DESCRIPTION | DESCRIPTION | DESCRIPTION | DESCRIPTION
<ins>SCENARIO</ins>|<ins>SCENARIO</ins> |<ins>SCENARIO</ins> | EXAMPLES
&nbsp;           | EXAMPLES    | &nbsp;           |<ins>SCENARIO</ins>
MESSAGES    | MESSAGES    | MESSAGES    | MESSAGES
PERSONALITY | PERSONALITY | PERSONALITY | PERSONALITY
MESSAGES    | MESSAGES    | MESSAGES    | MESSAGES

That happens, because prompt construction looks like this:
```js
let finalPromt = worldInfoBefore + storyString + worldInfoAfter + afterScenarioAnchor + mesExmString + mesSendString + generatedPromtCache + promptBias;
```
but ST with pinning enabled takes a shortcut by appending the examples directly to `storyString` instead of preparing proper `mesExmString`. IMO this makes the code more confusing than it needs to be, and in the end it is not even a shortcut, as evidenced be the number of lines deleted in this PR. ;) I also compared with `prepareOpenAIMessages()` and it seems that OpenAI handler behaves as expected (i.e. like TAI in the tables above).

This PR adjusts prompt structure for ST with pinning to match all other cases: ST without pinning, TAI regardless of pinning, ST OpenAI regardless of pinning.

And another thing. Until now, pinned examples were being added using this code:
```js
for (let example of mesExamplesArray) {
    storyString += appendToStoryString(example, '');
}
```
which at a glance looks OK, but the thing is that all examples are already terminated with a newline, so after `appendToStoryString()` adds another one, the result is a blank line:
```
<START>
A: hi
B: hi

<START>
A: hi
B: hi

```
and with example separator disabled even 2 consecutive blank lines. This PR adjust the formatting to match what happens without pinning:
```
<START>
A: hi
B: hi
<START>
A: hi
B: hi
```
So the end result of this PR is that prompt for short chats looks identical with and without pinning.

And last but not least, this PR improves code structure to make it easier to preserve consistency if similar adjustments to example messages (ordering, formatting) are needed in the future.
