### PR TITLE
Improve Docker image size and build speed

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+.git
 node_modules
 npm-debug.log
 readme*

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN \
   echo "*** Cleanup ***" && \
   mv "./docker/docker-entrypoint.sh" "./" && \
   rm -rf "./docker" && \
-  rm -rf "./.git" && \
   echo "*** Make docker-entrypoint.sh executable ***" && \
   chmod +x "./docker-entrypoint.sh" && \
   echo "*** Convert line endings to Unix format ***" && \


### PR DESCRIPTION
The `.git` directory just after cloning the repo weighs 108 MB, and will keep growing. Even more if using it for development – for me it has 140 MB and thousands of files. In my case this change cuts down image size by 30% and build time from 15 seconds to 5.