### PR TITLE
Auto fix generated broken markdown text & option to disable automatic scroll chat to bottom

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2226,19 +2226,19 @@ function fixMarkdown(text) {
     // and you HAVE to handle the cases where multiple pairs of asterisks exist in the same line
     // i.e. "^example * text* * harder problem *\n" -> "^example *text* *harder problem*\n"
 
-    // Find pairs of asterisks and capture the text in between them
-    const asterisks = /\*{2}|(\*\s*\S.*?\S\s*\*)/g;
+    // Find pairs of formatting characters and capture the text in between them
+    const format = /(\*{2}|__|\*|_|~~)(\s*\S.*?\S\s*)(\1)/g;
     let matches = [];
     let match;
-    while ((match = asterisks.exec(text)) !== null) {
+    while ((match = format.exec(text)) !== null) {
         matches.push(match);
     }
 
-    // Iterate through the matches and replace spaces immediately beside asterisks
+    // Iterate through the matches and replace consecutive spaces immediately beside formatting characters
     let newText = text;
     for (let i = matches.length - 1; i >= 0; i--) {
         let matchText = matches[i][0];
-        let replacementText = matchText.replace(/\s*(?<=\*)\s|\s(?=\*)\s*/g, '');
+        let replacementText = matchText.replace(/\s*(?<=\S)(\s+)(?=\S)/g, '');
         newText = newText.slice(0, matches[i].index) + replacementText + newText.slice(matches[i].index + matchText.length);
     }
 

--- a/public/script.js
+++ b/public/script.js
@@ -440,6 +440,8 @@ let novel_tier;
 let novelai_settings;
 let novelai_setting_names;
 
+let scrollChatToBottomAuto = true;
+let autoFixGeneratedTextMarkdown = true;
 //css
 var bg1_toggle = true; // inits the BG as BG1
 var css_mes_bg = $('<div class="mes"></div>').css("background");
@@ -1068,8 +1070,10 @@ function addOneMessage(mes, { type = "normal", insertAfter = null, scroll = true
 }
 
 function scrollChatToBottom() {
-    // var $textchat = $("#chat");
-    // $textchat.scrollTop(($textchat[0].scrollHeight));
+    if (scrollChatToBottomAuto) {
+        var $textchat = $("#chat");
+        $textchat.scrollTop(($textchat[0].scrollHeight));
+    }
 }
 
 function substituteParams(content, _name1, _name2) {
@@ -2872,6 +2876,12 @@ async function getSettings(type) {
 
                 // Load- character tags
                 loadTagsSettings(settings);
+
+                // Others, TODO: move to power user settings
+                if (settings.scrollChatToBottomAuto !== undefined)
+                    scrollChatToBottomAuto = !!settings.scrollChatToBottomAuto;
+                if (settings.autoFixGeneratedTextMarkdown !== undefined)
+                    autoFixGeneratedTextMarkdown = !!settings.autoFixGeneratedTextMarkdown;
 
                 //Enable GUI deference settings if GUI is selected for Kobold
                 if (main_api === "kobold") {


### PR DESCRIPTION
Setting to fix generated broken markdown text
`autoFixGeneratedTextMarkdown`
option to disable automatic scroll chat to bottom, as it is horrible while streaming text, default is unchanged
`scrollChatToBottomAuto`

markdown:
    // e.g.:
    // "^example * text*\n" -> "^example *text*\n"
    // "^*example * text\n" -> "^*example* text\n"
    // "^example *text *\n" -> "^example *text*\n"
    // "^* example * text\n" -> "^*example* text\n"