### PR TITLE
Add Silero TTS. Uncouple TTS Provider from TTS extension better.

### DIFF
--- a/public/scripts/extensions/tts/elevenlabs.js
+++ b/public/scripts/extensions/tts/elevenlabs.js
@@ -5,48 +5,24 @@ class ElevenLabsTtsProvider {
     // Config //
     //########//
 
-    API_KEY
-    settings = this.defaultSettings
+    settings
     voices = []
-
-    set API_KEY(apiKey) {
-        this.API_KEY = apiKey
-    }
-    get API_KEY() {
-        return this.API_KEY
-    }
+    
     get settings() {
         return this.settings
     }
 
-    updateSettings(settings) {
-        console.info("Settings updated")
-        if("stability" in settings && "similarity_boost" in settings){
-            this.settings = settings
-            $('#elevenlabs_tts_stability').val(this.settings.stability)
-            $('#elevenlabs_tts_similarity_boost').val(this.settings.similarity_boost)
-            this.onSettingsChange()
-        } else {
-            throw `Invalid settings passed to ElevenLabs: ${JSON.stringify(settings)}`
-        }
-    }
-
     defaultSettings = {
         stability: 0.75,
-        similarity_boost: 0.75
-    }
-
-    onSettingsChange() {
-        this.settings = {
-            stability: $('#elevenlabs_tts_stability').val(),
-            similarity_boost: $('#elevenlabs_tts_similarity_boost').val()
-        }
-        $('#elevenlabs_tts_stability_output').text(this.settings.stability)
-        $('#elevenlabs_tts_similarity_boost_output').text(this.settings.similarity_boost)
+        similarity_boost: 0.75,
+        apiKey: "",
+        voiceMap: {}
     }
 
     get settingsHtml() {
         let html = `
+        <label for="elevenlabs_tts_api_key">API Key</label>
+        <input id="elevenlabs_tts_api_key" type="text" class="text_pole" placeholder="<API Key>"/>
         <label for="elevenlabs_tts_stability">Stability: <span id="elevenlabs_tts_stability_output"></span></label>
         <input id="elevenlabs_tts_stability" type="range" value="${this.defaultSettings.stability}" min="0" max="1" step="0.05" />
         <label for="elevenlabs_tts_similarity_boost">Similarity Boost: <span id="elevenlabs_tts_similarity_boost_output"></span></label>
@@ -55,9 +31,58 @@ class ElevenLabsTtsProvider {
         return html
     }
 
-    //#############//
-    //  Management //
-    //#############//
+    onSettingsChange() {
+        // Update dynamically
+        this.settings.stability = $('#elevenlabs_tts_stability').val()
+        this.settings.similarity_boost = $('#elevenlabs_tts_similarity_boost').val()
+    }
+    
+
+    loadSettings(settings) {
+        // Pupulate Provider UI given input settings
+        if (Object.keys(settings).length == 0) {
+            console.info("Using default TTS Provider settings")
+        }
+
+        // Only accept keys defined in defaultSettings
+        this.settings = this.defaultSettings
+
+        for (const key in settings){
+            if (key in this.settings){
+                this.settings[key] = settings[key]
+            } else {
+                throw `Invalid setting passed to TTS Provider: ${key}`
+            }
+        }
+
+        $('#elevenlabs_tts_stability').val(this.settings.stability)
+        $('#elevenlabs_tts_similarity_boost').val(this.settings.similarity_boost)
+        $('#elevenlabs_tts_api_key').val(this.settings.apiKey)
+        console.info("Settings loaded")
+    }
+
+    async onApplyClick() {
+        // Update on Apply click
+        return await this.updateApiKey().catch( (error) => {
+            throw error
+        })
+    }
+    
+    
+    async updateApiKey() {
+        // Using this call to validate API key
+        this.settings.apiKey = $('#elevenlabs_tts_api_key').val()
+
+        await this.fetchTtsVoiceIds().catch(error => {
+            throw `TTS API key validation failed`
+        })
+        this.settings.apiKey = this.settings.apiKey
+        console.debug(`Saved new API_KEY: ${this.settings.apiKey}`)
+    }
+
+    //#################//
+    //  TTS Interfaces //
+    //#################//
 
     async getVoice(voiceName) {
         if (this.voices.length == 0) {
@@ -72,6 +97,25 @@ class ElevenLabsTtsProvider {
         return match
     }
 
+
+    async generateTts(text, voiceId){
+        const historyId = await this.findTtsGenerationInHistory(text, voiceId)
+    
+        let response
+        if (historyId) {
+            console.debug(`Found existing TTS generation with id ${historyId}`)
+            response = await this.fetchTtsFromHistory(historyId)
+        } else {
+            console.debug(`No existing TTS generation found, requesting new generation`)
+            response = await this.fetchTtsGeneration(text, voiceId)
+        }
+        return response
+    }
+    
+    //###################//
+    //  Helper Functions //
+    //###################//
+    
     async findTtsGenerationInHistory(message, voiceId) {
         const ttsHistory = await this.fetchTtsHistory()
         for (const history of ttsHistory) {
@@ -85,12 +129,13 @@ class ElevenLabsTtsProvider {
         return ''
     }
 
+
     //###########//
     // API CALLS //
     //###########//
     async fetchTtsVoiceIds() {
         const headers = {
-            'xi-api-key': this.API_KEY
+            'xi-api-key': this.settings.apiKey
         }
         const response = await fetch(`https://api.elevenlabs.io/v1/voices`, {
             headers: headers
@@ -104,7 +149,7 @@ class ElevenLabsTtsProvider {
 
     async fetchTtsVoiceSettings() {
         const headers = {
-            'xi-api-key': this.API_KEY
+            'xi-api-key': this.settings.apiKey
         }
         const response = await fetch(
             `https://api.elevenlabs.io/v1/voices/settings/default`,
@@ -125,7 +170,7 @@ class ElevenLabsTtsProvider {
             {
                 method: 'POST',
                 headers: {
-                    'xi-api-key': this.API_KEY,
+                    'xi-api-key': this.settings.apiKey,
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({
@@ -146,7 +191,7 @@ class ElevenLabsTtsProvider {
             `https://api.elevenlabs.io/v1/history/${history_item_id}/audio`,
             {
                 headers: {
-                    'xi-api-key': this.API_KEY
+                    'xi-api-key': this.settings.apiKey
                 }
             }
         )
@@ -158,7 +203,7 @@ class ElevenLabsTtsProvider {
 
     async fetchTtsHistory() {
         const headers = {
-            'xi-api-key': this.API_KEY
+            'xi-api-key': this.settings.apiKey
         }
         const response = await fetch(`https://api.elevenlabs.io/v1/history`, {
             headers: headers

--- a/public/scripts/extensions/tts/silerotts.js
+++ b/public/scripts/extensions/tts/silerotts.js
@@ -1,0 +1,127 @@
+export { SileroTtsProvider }
+
+class SileroTtsProvider {
+    //########//
+    // Config //
+    //########//
+
+    settings
+    voices = []
+
+    defaultSettings = {
+        provider_endpoint: "http://localhost:8001/tts",
+        voiceMap: {}
+    }
+    
+    get settingsHtml() {
+        let html = `
+        <label for="silero_tts_endpoint">Provider Endpoint:</label>
+        <input id="silero_tts_endpoint" type="text" class="text_pole" maxlength="250" value="${this.defaultSettings.provider_endpoint}"/>
+        <span> A simple Python Silero TTS Server can be found <a href="https://github.com/ouoertheo/silero-api-server">here</a>.</span>
+        `
+        return html
+    }
+    
+    onSettingsChange() {
+        // Used when provider settings are updated from UI
+        this.settings.provider_endpoint = $('#silero_tts_endpoint').val()
+    }
+
+    loadSettings(settings) {
+        // Pupulate Provider UI given input settings
+        if (Object.keys(settings).length == 0) {
+            console.info("Using default TTS Provider settings")
+        }
+
+        // Only accept keys defined in defaultSettings
+        this.settings = this.defaultSettings
+
+        for (const key in settings){
+            if (key in this.settings){
+                this.settings[key] = settings[key]
+            } else {
+                throw `Invalid setting passed to TTS Provider: ${key}`
+            }
+        }
+        
+        $('#silero_tts_endpoint').text(this.settings.provider_endpoint)
+        console.info("Settings loaded")
+    }
+
+    
+    async onApplyClick() {
+        return
+    }
+
+    //#################//
+    //  TTS Interfaces //
+    //#################//
+    
+    async getVoice(voiceName) {
+        if (this.voices.length == 0) {
+            this.voices = await this.fetchTtsVoiceIds()
+        }
+        const match = this.voices.filter(
+            sileroVoice => sileroVoice.name == voiceName
+        )[0]
+        if (!match) {
+            throw `TTS Voice name ${voiceName} not found`
+        }
+        return match
+    }
+
+    async generateTts(text, voiceId){
+        const response = await this.fetchTtsGeneration(text, voiceId)
+        return response
+    }
+
+    //###########//
+    // API CALLS //
+    //###########//
+    async fetchTtsVoiceIds() {
+        const response = await fetch(`${this.settings.provider_endpoint}/speakers`)
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${await response.json()}`)
+        }
+        const responseJson = await response.json()
+        return responseJson
+    }
+
+    async fetchTtsGeneration(inputText, voiceId) {
+        console.info(`Generating new TTS for voice_id ${voiceId}`)
+        const response = await fetch(
+            `${this.settings.provider_endpoint}/generate`,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({
+                    "text": inputText,
+                    "speaker": voiceId
+                })
+            }
+        )
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${await response.json()}`)
+        }
+        return response
+    }
+
+    async fetchTtsFromHistory(history_item_id) {
+        console.info(`Fetched existing TTS with history_item_id ${history_item_id}`)
+        const response = await fetch(
+            `https://api.elevenlabs.io/v1/history/${history_item_id}/audio`,
+            {
+                headers: {
+                    'xi-api-key': this.API_KEY
+                }
+            }
+        )
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}: ${await response.json()}`)
+        }
+        return response
+    }
+
+}


### PR DESCRIPTION
What's in the code?
I decoupled the TTS main extension code from the TTS provider code enough to have multiple providers with a decent dev experience there.

I added a Silero TTS provider which connects to a little custom FastAPI+Uvicorn server I released on my Github account here https://github.com/ouoertheo/silero-api-server

I'm not sure if we want to hold off on release of this, since we can consider integrating my Silero server into the tavern extras code. That's certainly an option.
