### PR TITLE
Fix disappearing personality and unreliable anchors when swiping or with system messages

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1731,7 +1731,6 @@ async function Generate(type, automatic_trigger, force_name2) {
                 console.log('generating prompt');
                 chatString = "";
                 arrMes = arrMes.reverse();
-                let is_add_personality = false;
                 arrMes.forEach(function (item, i, arr) {//For added anchors and others
 
                     if (i >= arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) != name1 + ":") {
@@ -1739,12 +1738,11 @@ async function Generate(type, automatic_trigger, force_name2) {
                             item = item.substr(0, item.length - 1);
                         }
                     }
-                    if (i === arrMes.length - topAnchorDepth && count_view_mes >= topAnchorDepth && !is_add_personality) {
-                        is_add_personality = true;
+                    if (i === arrMes.length - topAnchorDepth && count_view_mes >= topAnchorDepth && !is_pygmalion) {
                         //chatString = chatString.substr(0,chatString.length-1);
                         //anchorAndPersonality = "[Genre: roleplay chat][Tone: very long messages with descriptions]";
                         let personalityAndAnchor = [charPersonality, anchorTop].filter(x => x).join(' ');
-                        if (personalityAndAnchor && !is_pygmalion) {
+                        if (personalityAndAnchor) {
                             item += "[" + personalityAndAnchor + ']\n';
                         }
                     }

--- a/public/script.js
+++ b/public/script.js
@@ -1458,7 +1458,6 @@ async function Generate(type, automatic_trigger, force_name2) {
             else if (type !== "swipe" && !isImpersonate) {
                 chat.length = chat.length - 1;
                 count_view_mes -= 1;
-                openai_msgs.pop();
                 $('#chat').children().last().hide(500, function () {
                     $(this).remove();
                 });
@@ -1546,7 +1545,7 @@ async function Generate(type, automatic_trigger, force_name2) {
         let mesExamplesArray = mesExamples.split(/<START>/gi).slice(1).map(block => `${blockHeading}\n${block.trim()}\n`);
 
         if (main_api === 'openai') {
-            const oai_chat = [...chat].filter(x => !x.is_system);
+            const oai_chat = chat.filter(x => !x.is_system);
 
             if (type == 'swipe') {
                 oai_chat.pop();

--- a/public/script.js
+++ b/public/script.js
@@ -1709,7 +1709,7 @@ async function Generate(type, automatic_trigger, force_name2) {
                 arrMes = arrMes.reverse();
                 arrMes.forEach(function (item, i, arr) {//For added anchors and others
 
-                    if (i >= arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) != name1 + ":") {
+                    if (i === arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) != name1 + ":") {
                         if (textareaText == "") {
                             item = item.substr(0, item.length - 1);
                         }
@@ -1722,16 +1722,16 @@ async function Generate(type, automatic_trigger, force_name2) {
                             item += "[" + personalityAndAnchor + ']\n';
                         }
                     }
-                    if (i >= arrMes.length - 1 && coreChat.length > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":" && !is_pygmalion) {//For add anchor in end
+                    if (i === arrMes.length - 1 && coreChat.length > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":" && !is_pygmalion) {//For add anchor in end
                         item = item.substr(0, item.length - 1);
                         //chatString+=postAnchor+"\n";//"[Writing style: very long messages]\n";
                         item = item + anchorBottom + "\n";
                     }
                     if (is_pygmalion) {
-                        if (i >= arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//for add name2 when user sent
+                        if (i === arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//for add name2 when user sent
                             item = item + name2 + ":";
                         }
-                        if (i >= arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) != name1 + ":") {//for add name2 when continue
+                        if (i === arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) != name1 + ":") {//for add name2 when continue
                             if (textareaText == "") {
                                 item = item + '\n' + name2 + ":";
                             }

--- a/public/script.js
+++ b/public/script.js
@@ -1485,6 +1485,7 @@ async function Generate(type, automatic_trigger, force_name2) {
 
         // Compute anchors
         const topAnchorDepth = 8;
+        const bottomAnchorThreshold = 8;
         let anchorTop = '';
         let anchorBottom = '';
         if (!is_pygmalion) {
@@ -1725,7 +1726,7 @@ async function Generate(type, automatic_trigger, force_name2) {
             generatedPromtCache += cycleGenerationPromt;
             if (generatedPromtCache.length == 0) {
                 if (main_api === 'openai') {
-                    generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, anchorBottom);
+                    generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, bottomAnchorThreshold, anchorBottom);
                 }
 
                 console.log('generating prompt');
@@ -1746,7 +1747,7 @@ async function Generate(type, automatic_trigger, force_name2) {
                             item += "[" + personalityAndAnchor + ']\n';
                         }
                     }
-                    if (i >= arrMes.length - 1 && count_view_mes > 8 && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":" && !is_pygmalion) {//For add anchor in end
+                    if (i >= arrMes.length - 1 && count_view_mes > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":" && !is_pygmalion) {//For add anchor in end
                         item = item.substr(0, item.length - 1);
                         //chatString+=postAnchor+"\n";//"[Writing style: very long messages]\n";
                         item = item + anchorBottom + "\n";

--- a/public/script.js
+++ b/public/script.js
@@ -1214,14 +1214,7 @@ function getExtensionPrompt(position = 0, depth = undefined, separator = "\n") {
 
 function baseChatReplace(value, name1, name2) {
     if (value !== undefined && value.length > 0) {
-        if (is_pygmalion) {
-            value = value.replace(/{{user}}:/gi, "You:");
-            value = value.replace(/<USER>:/gi, "You:");
-        }
-        value = value.replace(/{{user}}/gi, name1);
-        value = value.replace(/{{char}}/gi, name2);
-        value = value.replace(/<USER>/gi, name1);
-        value = value.replace(/<BOT>/gi, name2);
+        value = substituteParams(value, is_pygmalion ? "You:" : name1, name2);
 
         if (power_user.collapse_newlines) {
             value = collapseNewlines(value);
@@ -1544,6 +1537,11 @@ async function Generate(type, automatic_trigger, force_name2) {
                         is_pygmalion ? '<START>' : `This is how ${name2} should talk`;
         let mesExamplesArray = mesExamples.split(/<START>/gi).slice(1).map(block => `${blockHeading}\n${block.trim()}\n`);
 
+        // First message in fresh 1-on-1 chat reacts to user/character settings changes
+        if (chat.length) {
+            chat[0].mes = substituteParams(chat[0].mes);
+        }
+
         if (main_api === 'openai') {
             const oai_chat = chat.filter(x => !x.is_system);
 
@@ -1587,12 +1585,6 @@ async function Generate(type, automatic_trigger, force_name2) {
         console.log('pre-replace chat.length = ' + chat.length);
         for (let i = chat.length - 1, j = 0; i >= 0; i--, j++) {
             let charName = selected_group ? chat[j].name : name2;
-            if (j == 0) {
-                chat[j]['mes'] = chat[j]['mes'].replace(/{{user}}/gi, name1);
-                chat[j]['mes'] = chat[j]['mes'].replace(/{{char}}/gi, charName);
-                chat[j]['mes'] = chat[j]['mes'].replace(/<USER>/gi, name1);
-                chat[j]['mes'] = chat[j]['mes'].replace(/<BOT>/gi, charName);
-            }
             let this_mes_ch_name = '';
             if (chat[j]['is_user']) {
                 this_mes_ch_name = name1;

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -148,10 +148,6 @@ function setOpenAIMessages(chat) {
     // clean openai msgs
     openai_msgs = [];
     for (let i = chat.length - 1; i >= 0; i--) {
-        // first greeting message
-        if (j == 0) {
-            chat[j]['mes'] = substituteParams(chat[j]['mes']);
-        }
         let role = chat[j]['is_user'] ? 'user' : 'assistant';
         let content = chat[j]['mes'];
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -198,7 +198,7 @@ function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, b
                 item = `[${name2} is ${personalityAndAnchor}]\n${item}`;
             }
         }
-        if (i >= openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end
+        if (i === openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end
             item = anchorBottom + "\n" + item;
         }
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -199,7 +199,7 @@ function setOpenAIMessageExamples(mesExamplesArray) {
     }
 }
 
-function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, anchorBottom) {
+function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, bottomAnchorThreshold, anchorBottom) {
     openai_msgs = openai_msgs.reverse();
     openai_msgs.forEach(function (msg, i, arr) {//For added anchors and others
         let item = msg["content"];
@@ -209,7 +209,7 @@ function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, a
                 item = `[${name2} is ${personalityAndAnchor}]\n${item}`;
             }
         }
-        if (i >= openai_msgs.length - 1 && count_view_mes > 8 && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end
+        if (i >= openai_msgs.length - 1 && count_view_mes > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end
             item = anchorBottom + "\n" + item;
         }
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -201,14 +201,12 @@ function setOpenAIMessageExamples(mesExamplesArray) {
 
 function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, anchorBottom) {
     openai_msgs = openai_msgs.reverse();
-    let is_add_personality = false;
     openai_msgs.forEach(function (msg, i, arr) {//For added anchors and others
         let item = msg["content"];
-        if (i === openai_msgs.length - topAnchorDepth && count_view_mes >= topAnchorDepth && !is_add_personality) {
-            is_add_personality = true;
-            if ((anchorTop != "" || charPersonality != "")) {
-                if (anchorTop != "") charPersonality += ' ';
-                item = `[${name2} is ${charPersonality}${anchorTop}]\n${item}`;
+        if (i === openai_msgs.length - topAnchorDepth && count_view_mes >= topAnchorDepth) {
+            let personalityAndAnchor = [charPersonality, anchorTop].filter(x => x).join(' ');
+            if (personalityAndAnchor) {
+                item = `[${name2} is ${personalityAndAnchor}]\n${item}`;
             }
         }
         if (i >= openai_msgs.length - 1 && count_view_mes > 8 && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -7,7 +7,6 @@
 import {
     saveSettingsDebounced,
     substituteParams,
-    count_view_mes,
     checkOnlineStatus,
     setOnlineStatus,
     getExtensionPrompt,
@@ -156,12 +155,6 @@ function setOpenAIMessages(chat) {
             content = `${chat[j].name}: ${content}`;
         }
 
-        // system messages produce no content
-        if (chat[j]['is_system']) {
-            role = 'system';
-            content = '';
-        }
-
         // replace bias markup
         //content = (content ?? '').replace(/{.*}/g, '');
         content = (content ?? '').replace(/{{(\*?.+?\*?)}}/g, '');
@@ -199,13 +192,13 @@ function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, b
     openai_msgs = openai_msgs.reverse();
     openai_msgs.forEach(function (msg, i, arr) {//For added anchors and others
         let item = msg["content"];
-        if (i === openai_msgs.length - topAnchorDepth && count_view_mes >= topAnchorDepth) {
+        if (i === openai_msgs.length - topAnchorDepth) {
             let personalityAndAnchor = [charPersonality, anchorTop].filter(x => x).join(' ');
             if (personalityAndAnchor) {
                 item = `[${name2} is ${personalityAndAnchor}]\n${item}`;
             }
         }
-        if (i >= openai_msgs.length - 1 && count_view_mes > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end
+        if (i >= openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end
             item = anchorBottom + "\n" + item;
         }
 


### PR DESCRIPTION
The problem is that part of personality/anchors logic depends on the number of visible messages (`count_view_mes`), while another part on the number of messages actually considered for the prompt, and they are not always the same. For example, even though both *regenerate* and *swipe* are supposed to recreate AI response, *regenerate* removes the last message completely, while *swipe* only from a local array, which leads to inconsistent message count and can cause prompts with missing or prematurely activated elements.

Example 1:
* 7 messages in the chat, send 8th, receive 9th → bottom anchor absent
* 9 messages in the chat, regenerate 9th → bottom anchor absent
* 9 messages in the chat, swipe 9th → bottom anchor **present**

Example 2:
* 6 messages in the chat, send 7th, receive 8th → personality in the story
* 8 messages in the chat, regenerate 8th → personality in the story
* 8 messages in the chat, swipe 8th → personality **not present in the prompt at all**

Another thing that adversely affects placement of personality and anchors is presence of system messages. Even though their content does not appear in the prompt, they still count towards `count_view_mes` and thus have an effect on the prompt, which can be demonstrated by this:
* create a new chat, send a message → personality in the story, anchors absent
* create a new chat, send `/?` 8 times to get a few help messages from the system, send a message → same 2 messages in the prompt, but also both anchors are present, personality moved to the top anchor, and the top anchor resides on the same depth as the bottom anchor.

This PR addresses the mentioned issues and simplifies the code along the way.