### PR TITLE
Fix truncated swipes when multigen is enabled

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2321,7 +2321,7 @@ function saveReply(type, getMessage, this_mes_is_name) {
     getMessage = img.getMessage;
 
     if (type === 'swipe') {
-        chat[chat.length - 1]['swipes'][chat[chat.length - 1]['swipes'].length] = getMessage;
+        chat[chat.length - 1]['swipes'].length++;
         if (chat[chat.length - 1]['swipe_id'] === chat[chat.length - 1]['swipes'].length - 1) {
             //console.log(getMessage);
             chat[chat.length - 1]['mes'] = getMessage;
@@ -2364,6 +2364,12 @@ function saveReply(type, getMessage, this_mes_is_name) {
         saveImageToMessage(img, chat[chat.length - 1]);
         addOneMessage(chat[chat.length - 1]);
     }
+
+    const item = chat[chat.length - 1];
+    if (item['swipe_id'] !== undefined) {
+        item['swipes'][item['swipes'].length - 1] = item['mes'];
+    }
+
     return { type, getMessage };
 }
 


### PR DESCRIPTION
#164 introduced streaming-like multigen, but without regard for the swipes feature, resulting in a number of bugs:
1. Swipes become truncated to the first chunk. You can see the entire message being generated, but when you switch to another swipe and back, you come back to a partially deleted message.
2. Right swipe button reappears just after the first chunk arrives, before generation is complete, allowing you to click it and get sort of a fake swipe, for which the counter below the button overflows by 1 (e.g. 4/3) and message content is a duplicate of the previous one. This is temporary – after clicking the left swipe button, this fake swipe goes away (but unfortunately the response is partially lost because of bug 1).
3. If you decide to view another swipe while generation is still running (by clicking the left swipe button), multigen output will be appended to the currently visible swipe instead of the one for which it is supposed to be generated. This is also temporary – after generation is complete, it is possible to switch to another swipe and back to see the correct content for all swipes (well, at least as much of it as bug 1 allows).

I usually do not use multigen, but the prospect of data loss was bothering me, so here's a band-aid fix for bug 1.