### PR TITLE
Fix group chat member names in openai.js

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -311,7 +311,11 @@ async function prepareOpenAIMessages(name2, storyString, worldInfoBefore, worldI
     if (selected_group) {
         // set "special" group nudging messages
         const groupMembers = groups.find(x => x.id === selected_group)?.members;
-        const names = Array.isArray(groupMembers) ? groupMembers.join(', ') : '';
+        let names = '';
+        if (Array.isArray(groupMembers)) {
+            names = groupMembers.map(member => characters.find(c => c.avatar === member)).map((x) => x.name);
+            names = names.join(', ')
+        }
         new_chat_msg.content = `[Start a new group chat. Group members: ${names}]`;
         let group_nudge = { "role": "system", "content": `[Write the next reply only as ${name2}]` };
         openai_msgs.push(group_nudge);


### PR DESCRIPTION
Group members are not by card name, so look up the actual character name instead