### PR TITLE
Fix unreliable buttons for disabling/enabling extensions

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -2800,7 +2800,7 @@ function selectKoboldGuiPreset() {
 
 async function saveSettings(type) {
     //console.log('Entering settings with name1 = '+name1);
-    jQuery.ajax({
+    return jQuery.ajax({
         type: "POST",
         url: "/savesettings",
         data: JSON.stringify({


### PR DESCRIPTION
The sequence of events looks like this, at least on my system:
1. Click a link to disable/enable an extension.
2. Send a request to save the updated settings.
3. Reload the page before the server can process the request.
4. Ask the the server for the settings and receive the old version.
5. The server finally saves the settings sent in step 2.
6. Something else on the page triggers another save, with the old settings received in step 4, so the server reverts the settings to what they were before step 1.

That happens, because `disable/enableExtension()` does `await saveSettings()` before reloading the page, but `saveSettings()` returns nothing to await on. I did not find anything else in the codebase that awaits `saveSettings()`, so I believe this fix does not have any side-effetcs.