### PR TITLE
Make the app work in Docker without a volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,18 +23,14 @@ COPY . ./
 
 # Copy default chats, characters and user avatars to <folder>.default folder
 RUN \
-  echo "*** Copy default chats, characters and user avatars to <folder>.default folder ***" && \
-  mv "./public/characters"    "./public/characters.default" && \
-  mv "./public/chats"         "./public/chats.default" && \
-  mv "./public/User Avatars"  "./public/User Avatars.default" && \
-  mv "./public/settings.json" "./public/settings.json.default" && \
+  IFS="," RESOURCES="characters,chats,User Avatars,settings.json" && \
+  \
+  echo "*** Store default $RESOURCES in <folder>.default ***" && \
+  for R in $RESOURCES; do mv "public/$R" "public/$R.default"; done && \
   \
   echo "*** Create symbolic links to config directory ***" && \
-  ln -s "${APP_HOME}/config/characters"     "${APP_HOME}/public/characters" && \
-  ln -s "${APP_HOME}/config/chats"          "${APP_HOME}/public/chats" && \
-  ln -s "${APP_HOME}/config/User Avatars"   "${APP_HOME}/public/User Avatars" && \
-  ln -s "${APP_HOME}/config/settings.json"  "${APP_HOME}/public/settings.json" && \
-  mkdir "${APP_HOME}/config"
+  for R in $RESOURCES; do ln -s "../config/$R" "public/$R"; done && \
+  mkdir "config"
 
 # Cleanup unnecessary files
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN \
   ln -s "${APP_HOME}/config/characters"     "${APP_HOME}/public/characters" && \
   ln -s "${APP_HOME}/config/chats"          "${APP_HOME}/public/chats" && \
   ln -s "${APP_HOME}/config/User Avatars"   "${APP_HOME}/public/User Avatars" && \
-  ln -s "${APP_HOME}/config/settings.json"  "${APP_HOME}/public/settings.json"
+  ln -s "${APP_HOME}/config/settings.json"  "${APP_HOME}/public/settings.json" && \
+  mkdir "${APP_HOME}/config"
 
 # Cleanup unnecessary files
 RUN \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,26 +1,26 @@
 #!/bin/sh
 
 # Check if the "characters" directory is empty
-if [ -z "$(ls -A /home/node/app/config/characters)" ]; then
-  echo "Characters directory is empty. Copying default characters."
+if [ ! -e "/home/node/app/config/characters" ]; then
+  echo "Characters directory not found. Copying default characters."
   mv /home/node/app/public/characters.default /home/node/app/config/characters
 fi
 
 # Check if the "chats" directory is empty
-if [ -z "$(ls -A /home/node/app/config/chats)" ]; then
-  echo "Chats directory is empty. Copying default chats."
+if [ ! -e "/home/node/app/config/chats" ]; then
+  echo "Chats directory not found. Copying default chats."
   mv /home/node/app/public/chats.default /home/node/app/config/chats/
 fi
 
 # Check if the "User Avatars" directory is empty
-if [ -z "$(ls -A '/home/node/app/config/User Avatars')" ]; then
-  echo "User Avatars directory is empty. Copying default user avatars."
+if [ ! -e "/home/node/app/config/User Avatars" ]; then
+  echo "User Avatars directory not found. Copying default user avatars."
   mv /home/node/app/public/User\ Avatars.default /home/node/app/config/User\ Avatars/
 fi
 
 # Check if the "settings.json" file is not empty
-if [ ! -s "/home/node/app/config/settings.json" ]; then
-  echo "Settings file does not exist. Copying default settings."
+if [ ! -e "/home/node/app/config/settings.json" ]; then
+  echo "Settings file not found. Copying default settings."
   mv /home/node/app/public/settings.json.default /home/node/app/config/settings.json
 fi
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,28 +1,13 @@
 #!/bin/sh
 
-# Check if the "characters" directory is empty
-if [ ! -e "/home/node/app/config/characters" ]; then
-  echo "Characters directory not found. Copying default characters."
-  mv /home/node/app/public/characters.default /home/node/app/config/characters
-fi
-
-# Check if the "chats" directory is empty
-if [ ! -e "/home/node/app/config/chats" ]; then
-  echo "Chats directory not found. Copying default chats."
-  mv /home/node/app/public/chats.default /home/node/app/config/chats/
-fi
-
-# Check if the "User Avatars" directory is empty
-if [ ! -e "/home/node/app/config/User Avatars" ]; then
-  echo "User Avatars directory not found. Copying default user avatars."
-  mv /home/node/app/public/User\ Avatars.default /home/node/app/config/User\ Avatars/
-fi
-
-# Check if the "settings.json" file is not empty
-if [ ! -e "/home/node/app/config/settings.json" ]; then
-  echo "Settings file not found. Copying default settings."
-  mv /home/node/app/public/settings.json.default /home/node/app/config/settings.json
-fi
+# Initialize missing user files
+IFS="," RESOURCES="characters,chats,User Avatars,settings.json"
+for R in $RESOURCES; do
+  if [ ! -e "config/$R" ]; then
+    echo "Resource not found, copying from defaults: $R"
+    cp -r "public/$R.default" "config/$R"
+  fi
+done
 
 # Start the server
-exec node /home/node/app/server.js
+exec node server.js


### PR DESCRIPTION
The container crashes if configuration volume is not attached. There is a volume defined in `docker-compose.yml`, but Compose is not the only way someone may want to run the app. Moreover, initialization of user data does not work if directories exist but are empty, and the scripts are clunky with so much repeated code. This PR addresses all of that.