### PR TITLE
Fix bottom anchor never being included for OpenAI

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1860,7 +1860,7 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                 arrMes = arrMes.reverse();
                 arrMes.forEach(function (item, i, arr) {//For added anchors and others
 
-                    if (i === arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) != name1 + ":") {
+                    if (i === arrMes.length - 1 && !item.trim().startsWith(name1 + ":")) {
                         if (textareaText == "") {
                             item = item.substr(0, item.length - 1);
                         }
@@ -1873,21 +1873,21 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                             item += "[" + personalityAndAnchor + ']\n';
                         }
                     }
-                    if (i === arrMes.length - 1 && coreChat.length > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":" && !is_pygmalion) {//For add anchor in end
+                    if (i === arrMes.length - 1 && coreChat.length > bottomAnchorThreshold && item.trim().startsWith(name1 + ":") && !is_pygmalion) {//For add anchor in end
                         item = item.substr(0, item.length - 1);
                         //chatString+=postAnchor+"\n";//"[Writing style: very long messages]\n";
                         item = item + anchorBottom + "\n";
                     }
                     if (is_pygmalion) {
-                        if (i === arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//for add name2 when user sent
+                        if (i === arrMes.length - 1 && item.trim().startsWith(name1 + ":")) {//for add name2 when user sent
                             item = item + name2 + ":";
                         }
-                        if (i === arrMes.length - 1 && $.trim(item).substr(0, (name1 + ":").length) != name1 + ":") {//for add name2 when continue
+                        if (i === arrMes.length - 1 && !item.trim().startsWith(name1 + ":")) {//for add name2 when continue
                             if (textareaText == "") {
                                 item = item + '\n' + name2 + ":";
                             }
                         }
-                        if ($.trim(item).indexOf(name1) === 0) {
+                        if (item.trim().startsWith(name1)) {
                             item = item.replace(name1 + ':', 'You:');
                         }
                     }
@@ -2363,7 +2363,7 @@ function shouldContinueMultigen(getMessage) {
 function extractNameFromMessage(getMessage, force_name2, isImpersonate) {
     const nameToTrim = isImpersonate ? name1 : name2;
     let this_mes_is_name = true;
-    if (getMessage.indexOf(nameToTrim + ":") === 0) {
+    if (getMessage.startsWith(nameToTrim + ":")) {
         getMessage = getMessage.replace(nameToTrim + ':', '');
         getMessage = getMessage.trimStart();
     } else {

--- a/public/script.js
+++ b/public/script.js
@@ -1870,13 +1870,15 @@ async function Generate(type, { automatic_trigger, force_name2, resolve, reject,
                         //anchorAndPersonality = "[Genre: roleplay chat][Tone: very long messages with descriptions]";
                         let personalityAndAnchor = [charPersonality, anchorTop].filter(x => x).join(' ');
                         if (personalityAndAnchor) {
-                            item += "[" + personalityAndAnchor + ']\n';
+                            item += "[" + personalityAndAnchor + "]\n";
                         }
                     }
                     if (i === arrMes.length - 1 && coreChat.length > bottomAnchorThreshold && item.trim().startsWith(name1 + ":") && !is_pygmalion) {//For add anchor in end
-                        item = item.substr(0, item.length - 1);
                         //chatString+=postAnchor+"\n";//"[Writing style: very long messages]\n";
-                        item = item + anchorBottom + "\n";
+                        if (anchorBottom) {
+                            item = item.replace(/\n$/, " ");
+                            item += anchorBottom + "\n";
+                        }
                     }
                     if (is_pygmalion) {
                         if (i === arrMes.length - 1 && item.trim().startsWith(name1 + ":")) {//for add name2 when user sent

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -204,7 +204,7 @@ function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, b
                 item = `[${name2} is ${personalityAndAnchor}]\n${item}`;
             }
         }
-        if (i === openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && item.trim().startsWith(name1 + ":")) {//For add anchor in end
+        if (i === openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && msg.role === "user") {//For add anchor in end
             item = anchorBottom + "\n" + item;
         }
 

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -204,7 +204,7 @@ function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, b
                 item = `[${name2} is ${personalityAndAnchor}]\n${item}`;
             }
         }
-        if (i === openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && $.trim(item).substr(0, (name1 + ":").length) == name1 + ":") {//For add anchor in end
+        if (i === openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && item.trim().startsWith(name1 + ":")) {//For add anchor in end
             item = anchorBottom + "\n" + item;
         }
 
@@ -238,14 +238,14 @@ function parseExampleIntoIndividual(messageExampleString) {
         let cur_str = tmp[i];
         // if it's the user message, switch into user mode and out of bot mode
         // yes, repeated code, but I don't care
-        if (cur_str.indexOf(name1 + ":") === 0) {
+        if (cur_str.startsWith(name1 + ":")) {
             in_user = true;
             // we were in the bot mode previously, add the message
             if (in_bot) {
                 add_msg(name2, "system", "example_assistant");
             }
             in_bot = false;
-        } else if (cur_str.indexOf(name2 + ":") === 0) {
+        } else if (cur_str.startsWith(name2 + ":")) {
             in_bot = true;
             // we were in the user mode previously, add the message
             if (in_user) {

--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -205,7 +205,9 @@ function generateOpenAIPromptCache(charPersonality, topAnchorDepth, anchorTop, b
             }
         }
         if (i === openai_msgs.length - 1 && openai_msgs.length > bottomAnchorThreshold && msg.role === "user") {//For add anchor in end
-            item = anchorBottom + "\n" + item;
+            if (anchorBottom) {
+                item = anchorBottom + "\n" + item;
+            }
         }
 
         msg["content"] = item;


### PR DESCRIPTION
The bottom anchor condition in OpenAI handler was assuming content of messages to be formatted like `You: hello`, but in reality there is no name prefix,  the content is a separate field in the object `{ "role": "user", "content": "hello" }`. While on the topic of anchors and prefix checks, I also added a missing space in the non-OpenAI bottom anchor case and simplified the checks a bit.