### PR TITLE
Fix: extra space on prompt (due to  join(" ") on array)

### DIFF
--- a/public/scripts/openai.js
+++ b/public/scripts/openai.js
@@ -458,15 +458,15 @@ function getSystemPrompt(nsfw_toggle_prompt, enhance_definitions_prompt, wiBefor
     let whole_prompt = [];
 
     if (isImpersonate) {
-        whole_prompt = [nsfw_toggle_prompt, enhance_definitions_prompt, "\n\n", wiBefore, storyString, wiAfter, extensionPrompt];
+        whole_prompt = [nsfw_toggle_prompt, enhance_definitions_prompt, "\n\n" + wiBefore, storyString, wiAfter, extensionPrompt];
     }
     else {
         // If it's toggled, NSFW prompt goes first.
         if (oai_settings.nsfw_first) {
-            whole_prompt = [nsfw_toggle_prompt, oai_settings.main_prompt, enhance_definitions_prompt, "\n\n", wiBefore, storyString, wiAfter, extensionPrompt];
+            whole_prompt = [nsfw_toggle_prompt, oai_settings.main_prompt, enhance_definitions_prompt, "\n\n" + wiBefore, storyString, wiAfter, extensionPrompt];
         }
         else {
-            whole_prompt = [oai_settings.main_prompt, nsfw_toggle_prompt, enhance_definitions_prompt, "\n\n", wiBefore, storyString, wiAfter, extensionPrompt];
+            whole_prompt = [oai_settings.main_prompt, nsfw_toggle_prompt, enhance_definitions_prompt, "\n\n" + wiBefore, storyString, wiAfter, extensionPrompt];
         }
     }
     return whole_prompt;


### PR DESCRIPTION
Joining happens later, so this:
`["\n\n", wiBefore].join(" ")`
became this
`\n\n ${wiBefore}`
i.e.
`\n\n[extra starting space on the line]${wiBefore}`

the commit fixes this