### PR TITLE
hotfix on emtpy content: Was unable to open a certain chat without this

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -1183,6 +1183,10 @@ function scrollChatToBottom() {
 function substituteParams(content, _name1, _name2) {
     _name1 = _name1 ?? name1;
     _name2 = _name2 ?? name2;
+    if (!content) {
+        console.warn("No content on substituteParams")
+        return ''
+    }
 
     content = content.replace(/{{user}}/gi, _name1);
     content = content.replace(/{{char}}/gi, _name2);


### PR DESCRIPTION
`substituteParams` was being called with the argument `content` undefined.
its probably a bigger bug introduced, but this let me open my chat