### PR TITLE
Prepend [Feature Request] to template title

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
+title: "[Feature Request] "
 labels: ''
 assignees: ''
 


### PR DESCRIPTION
The power of the default.

I noticed the bug report template started with [BUG], so I thought it might be helpful to have feature requests be the same to help users keep requests in the same format.