### PR TITLE
Update docker-compose.yml to reflect sillytavern name

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,10 +1,10 @@
 version: "3"
 services:
-  tavernai:
+  sillytavern:
     build: ..
-    container_name: tavernai
-    hostname: tavernai
-    image: tavernai/tavernai:latest
+    container_name: sillytavern
+    hostname: sillytavern
+    image: cohee1207/sillytavern:latest
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
Docker compose file was still naming the image with tavernai. 
Last changes appear to be prior to the split so looks like it just needs to be renamed.