### PR TITLE
Add security override config for trusted network

### DIFF
--- a/config.conf
+++ b/config.conf
@@ -10,6 +10,11 @@ const enableExtensions = true; //Enables support for TavernAI-extras project
 const listen = true; // If true, Can be access from other device or PC. otherwise can be access only from hosting machine.
 const allowKeysExposure = false; // If true, private API keys could be fetched to the frontend.
 
+
+// If true, Allows insecure settings for listen, whitelist, and authentication.
+// Change this setting only on "trusted networks". Do not change this value unless you are aware of the issues that can arise from changing this setting and configuring a insecure setting.
+const securityOverride = false;
+
 module.exports = {
   port,
   whitelist, 
@@ -21,4 +26,5 @@ module.exports = {
   listen,
   disableThumbnails,
   allowKeysExposure,
+  securityOverride,
 };

--- a/server.js
+++ b/server.js
@@ -2715,8 +2715,12 @@ const setupTasks = async function () {
 }
 
 if (listen && !config.whitelistMode && !config.basicAuthMode) {
-    console.error('Your SillyTavern is currently unsecurely open to the public. Enable whitelisting or basic authentication.');
-    process.exit(1);
+	if (config.securityOverride)
+		console.warn("Security has been override. If it's not a trusted network, change the settings.");
+	else {
+		console.error('Your SillyTavern is currently unsecurely open to the public. Enable whitelisting or basic authentication.');
+		process.exit(1);
+	}
 }
 
 if (true === cliArguments.ssl)


### PR DESCRIPTION
I'm running SillyTavern in a trusted network, so I don't need authentication or whitelisting features. but SillyTavern will exited the server in these cases without provide any bypass configs.

These features can make less secure, but i added a security override setting with warning text in case you deliberately want to disable them.