### PR TITLE
Move KAI Horde to dedicated dropdown

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -980,67 +980,71 @@
                     <div id="main-API-selector-block">
                         <select id="main_api">
                             <option value="kobold">KoboldAI</option>
+                            <option value="koboldhorde">KoboldAI Horde</option>
                             <option value="textgenerationwebui">Text Gen WebUI (ooba)</option>
                             <option value="novel">NovelAI</option>
                             <option value="openai">OpenAI</option>
                             <option value="poe">Poe</option>
                         </select>
                     </div>
-                    <div id="kobold_api" style="position: relative;"> <!-- shows the kobold settings -->
+                    <div id="kobold_horde" style="position: relative;"> <!-- shows the kobold settings -->
                         <form action="javascript:void(null);" method="post" enctype="multipart/form-data">
-                            <label for="use_horde" class="checkbox_label">
-                                <input id="use_horde" type="checkbox" />
-                                Use Horde
+                        <div id="kobold_horde_block">
+                            <ul>
+                                <li>
+                                    <a target="_blank" href="https://horde.koboldai.net/register">Register a Horde account for faster queue times</a>
+                                </li>
+                                <li>
+                                    <a target="_blank" href="https://github.com/db0/AI-Horde-Worker#readme">Learn how to contribute your idle GPU cycles to the Horde</a>
+                                </li>
+                            </ul>
+
+                            <label for="horde_auto_adjust_context_length" class="checkbox_label">
+                                <input id="horde_auto_adjust_context_length" type="checkbox" />
+                                Adjust context size to worker capabilities
                             </label>
 
+                            <label for="horde_auto_adjust_response_length" class="checkbox_label">
+                                <input id="horde_auto_adjust_response_length" type="checkbox" />
+                                Adjust response length to worker capabilities
+                            </label>
+                            <h4>API key</h4>
+                            <h5>Get it here: <a target="_blank" href="https://horde.koboldai.net/register">Register</a><br>
+                                Enter <span class="monospace">0000000000</span> to use anonymous mode.
+                            </h5>
+                            <div>
+                                <a id="horde_kudos" href="javascript:void(0);">View my Kudos</a>
+                            </div>
+                            <div class="flex-container">
+                                <input id="horde_api_key" name="horde_api_key" class="text_pole flex1" maxlength="500" type="text" placeholder="0000000000" autocomplete="off">
+                                <div title="Clear your API key" class="menu_button fa-solid fa-circle-xmark clear-api-key" data-key="api_key_horde"></div>
+                            </div>
+                            <div class="neutral_warning">For privacy reasons, your API key will be hidden after you reload the page.</div>
+                            <h4 class="horde_model_title">
+                                Model
+                                <div id="horde_refresh" title="Refresh models" class="right_menu_button">
+                                    <div class="fa-solid fa-repeat "></div>
+                                </div>
+                            </h4>
+                            <small class="horde_multiple_hint">Hold Control / Command key to select multiple models.</small>
+                            <select id="horde_model" multiple>
+                                <option>-- Horde models not loaded --</option>
+                            </select>
+                        </div>
+                            <div id="online_status_horde">
+                                <div id="online_status_indicator_horde"></div>
+                                <div id="online_status_text_horde">Not connected</div>
+                            </div>
+                        </form>
+                    </div>
+                    <div id="kobold_api" style="position: relative;"> <!-- shows the kobold settings -->
+                        <form action="javascript:void(null);" method="post" enctype="multipart/form-data">
                             <div id="kobold_api_block">
                                 <h4>API url</h4>
                                 <h5>Example: http://127.0.0.1:5000/api </h5>
                                 <input id="api_url_text" name="api_url" class="text_pole" placeholder="http://127.0.0.1:5000/api" maxlength="500" value="" autocomplete="off">
                                 <input id="api_button" class="menu_button" type="submit" value="Connect">
                                 <div id="api_loading" class="api-load-icon fa-solid fa-hourglass fa-spin"></div>
-                            </div>
-                            <div id="kobold_horde_block">
-                                <ul>
-                                    <li>
-                                        <a target="_blank" href="https://horde.koboldai.net/register">Register a Horde account for faster queue times</a>
-                                    </li>
-                                    <li>
-                                        <a target="_blank" href="https://github.com/db0/AI-Horde-Worker#readme">Learn how to contribute your idle GPU cycles to the Horde</a>
-                                    </li>
-                                </ul>
-
-                                <label for="horde_auto_adjust_context_length" class="checkbox_label">
-                                    <input id="horde_auto_adjust_context_length" type="checkbox" />
-                                    Adjust context size to worker capabilities
-                                </label>
-
-                                <label for="horde_auto_adjust_response_length" class="checkbox_label">
-                                    <input id="horde_auto_adjust_response_length" type="checkbox" />
-                                    Adjust response length to worker capabilities
-                                </label>
-                                <h4>API key</h4>
-                                <h5>Get it here: <a target="_blank" href="https://horde.koboldai.net/register">Register</a><br>
-                                    Enter <span class="monospace">0000000000</span> to use anonymous mode.
-                                </h5>
-                                <div>
-                                    <a id="horde_kudos" href="javascript:void(0);">View my Kudos</a>
-                                </div>
-                                <div class="flex-container">
-                                    <input id="horde_api_key" name="horde_api_key" class="text_pole flex1" maxlength="500" type="text" placeholder="0000000000" autocomplete="off">
-                                    <div title="Clear your API key" class="menu_button fa-solid fa-circle-xmark clear-api-key" data-key="api_key_horde"></div>
-                                </div>
-                                <div class="neutral_warning">For privacy reasons, your API key will be hidden after you reload the page.</div>
-                                <h4 class="horde_model_title">
-                                    Model
-                                    <div id="horde_refresh" title="Refresh models" class="right_menu_button">
-                                        <div class="fa-solid fa-repeat "></div>
-                                    </div>
-                                </h4>
-                                <small class="horde_multiple_hint">Hold Control / Command key to select multiple models.</small>
-                                <select id="horde_model" multiple>
-                                    <option>-- Horde models not loaded --</option>
-                                </select>
                             </div>
                             <div id="online_status2">
                                 <div id="online_status_indicator2"></div>

--- a/public/scripts/horde.js
+++ b/public/scripts/horde.js
@@ -16,7 +16,6 @@ let models = [];
 
 let horde_settings = {
     models: [],
-    use_horde: false,
     auto_adjust_response_length: true,
     auto_adjust_context_length: false,
 };
@@ -180,7 +179,6 @@ function loadHordeSettings(settings) {
         Object.assign(horde_settings, settings.horde_settings);
     }
 
-    $('#use_horde').prop("checked", horde_settings.use_horde).trigger('input');
     $('#horde_auto_adjust_response_length').prop("checked", horde_settings.auto_adjust_response_length);
     $('#horde_auto_adjust_context_length').prop("checked", horde_settings.auto_adjust_context_length);
 }
@@ -208,23 +206,6 @@ async function showKudos() {
 }
 
 jQuery(function () {
-    $("#use_horde").on("input", async function () {
-        horde_settings.use_horde = !!$(this).prop("checked");
-
-        if (horde_settings.use_horde) {
-            $('#kobold_api_block').hide();
-            $('#kobold_horde_block').show();
-        }
-        else {
-            $('#kobold_api_block').show();
-            $('#kobold_horde_block').hide();
-        }
-
-        // Trigger status check
-        changeMainAPI();
-        saveSettingsDebounced();
-    });
-
     $("#horde_model").on("change", function () {
         horde_settings.models = $('#horde_model').val();
         console.log('Updated Horde models', horde_settings.models);

--- a/public/style.css
+++ b/public/style.css
@@ -1721,6 +1721,7 @@ input[type=search]:focus::-webkit-search-cancel-button {
 
 /* ------ online status indicators and texts. 2 = kobold AI, 3 = Novel AI  ----------*/
 #online_status2,
+#online_status_horde,
 .online_status4 {
     opacity: 0.5;
     margin-top: 2px;
@@ -1728,6 +1729,7 @@ input[type=search]:focus::-webkit-search-cancel-button {
 }
 
 #online_status_indicator2,
+#online_status_indicator_horde,
 .online_status_indicator4 {
     border-radius: 7px;
     width: 14px;
@@ -1737,6 +1739,7 @@ input[type=search]:focus::-webkit-search-cancel-button {
 }
 
 #online_status_text2,
+#online_status_text_horde,
 .online_status_text4 {
     margin-left: 4px;
     display: inline-block;


### PR DESCRIPTION
This should move the KAI horde out of the KAI area and into its own grouping.  This cleans up the code a bit by removing the extra event handler and all of the spare "kobold && horde enabled" checks and gets Horde "out of the way" for any possible KAI-local specific changes anyone might want to make.

I had to change how the hiding/showing of divs worked when you pick a different connection to do this.  Since kobold and horde share settings, having horde as a separate item caused the kobold option to hide all the divs that horde wanted.  Horde would display them, then the loop would grab kobold and immediately hide them again.

I cut the "active item" out of the loop so it only gets handled once, after the loop hides all the items from the other data, and that fixed the problem.