### PR TITLE
Fix race condition when saving settings for TTS

### DIFF
--- a/public/scripts/extensions/tts/index.js
+++ b/public/scripts/extensions/tts/index.js
@@ -362,15 +362,15 @@ function onApplyClick() {
     Promise.all([
         ttsProvider.onApplyClick(),
         updateVoiceMap()
-    ]).catch(error => {
+    ]).then(() => {
+        extension_settings.tts[ttsProviderName] = ttsProvider.settings
+        saveSettingsDebounced()
+        setTtsStatus('Successfully applied settings', true)
+        console.info(`Saved settings ${ttsProviderName} ${JSON.stringify(ttsProvider.settings)}`)
+    }).catch(error => {
         console.error(error)
         setTtsStatus(error, false)
     })
-    
-    extension_settings.tts[ttsProviderName] = ttsProvider.settings
-    saveSettingsDebounced()
-    setTtsStatus('Successfully applied settings', true)
-    console.info(`Saved settings ${ttsProviderName} ${JSON.stringify(ttsProvider.settings)}`)
 }
 
 function onEnableClick() {


### PR DESCRIPTION
Dipping my toe in the water for contributing, this time just making a really simple change to fix a race condition. Have a few local fixes I'd push, but figured I'd start with an easy/straightforward one. Basically, just fix it so the TTS settings aren't marked as applied until they actually _are_ applied (noting that, so far as I can tell, the promise doesn't wait to return, it just creates a promise and immediately moves on). At the absolute floor, this means better logging because the incorrect settings aren't logged out (what the TTS settings were before pressing the "apply" button).